### PR TITLE
Notification Center support

### DIFF
--- a/Classes/GitifierAppDelegate.m
+++ b/Classes/GitifierAppDelegate.m
@@ -16,6 +16,7 @@
 #import "Repository.h"
 #import "RepositoryListController.h"
 #import "StatusBarController.h"
+#import "NotificationControllerFactory.h"
 
 static NSString *SUEnableAutomaticChecksKey = @"SUEnableAutomaticChecks";
 static NSString *SUSendProfileInfoKey       = @"SUSendProfileInfo";
@@ -41,7 +42,7 @@ static CGFloat IntervalBetweenGrowls        = 0.05;
   ObserveDefaults(KeepWindowsOnTopKey);
   [self loadGitPath];
 
-  [[GrowlController sharedController] setRepositoryListController: self.repositoryListController];
+  [[NotificationControllerFactory sharedController] setRepositoryListController: self.repositoryListController];
 
   [self askAboutStats];
 
@@ -247,7 +248,7 @@ static CGFloat IntervalBetweenGrowls        = 0.05;
     remainingCommits = @[];
   }
 
-  GrowlController *growl = [GrowlController sharedController];
+  NSObject<NotificationController> *growl = [NotificationControllerFactory sharedController];
   NSInteger i = 0;
 
   for (Commit *commit in displayedCommits) {
@@ -278,8 +279,8 @@ static CGFloat IntervalBetweenGrowls        = 0.05;
 }
 
 - (void) repositoryCouldNotBeCloned: (Repository *) repository {
-  [[GrowlController sharedController] showGrowlWithError: @"Cached copy was deleted and can't be restored."
-                                              repository: repository];
+  [[NotificationControllerFactory sharedController] showGrowlWithError: @"Cached copy was deleted and can't be restored."
+                                                            repository: repository];
 }
 
 @end

--- a/Classes/GitifierAppDelegate.m
+++ b/Classes/GitifierAppDelegate.m
@@ -253,7 +253,7 @@ static CGFloat IntervalBetweenGrowls        = 0.05;
 
   for (Commit *commit in displayedCommits) {
     // intervals added because Growl 1.3 can't figure out the proper order by itself...
-    [growl performSelector: @selector(showGrowlWithCommit:) withObject: commit afterDelay: i * IntervalBetweenGrowls];
+    [growl performSelector: @selector(showNotificationWithCommit:) withObject: commit afterDelay: i * IntervalBetweenGrowls];
     i += 1;
   }
 
@@ -261,9 +261,9 @@ static CGFloat IntervalBetweenGrowls        = 0.05;
     SEL action;
 
     if (notificationLimit == 1) {
-      action = @selector(showGrowlWithCommitGroupIncludingAllCommits:);
+      action = @selector(showNotificationWithCommitGroupIncludingAllCommits:);
     } else {
-      action = @selector(showGrowlWithCommitGroupIncludingSomeCommits:);
+      action = @selector(showNotificationWithCommitGroupIncludingSomeCommits:);
     }
 
     [growl performSelector: action withObject: remainingCommits afterDelay: i * IntervalBetweenGrowls];
@@ -279,8 +279,8 @@ static CGFloat IntervalBetweenGrowls        = 0.05;
 }
 
 - (void) repositoryCouldNotBeCloned: (Repository *) repository {
-  [[NotificationControllerFactory sharedController] showGrowlWithError: @"Cached copy was deleted and can't be restored."
-                                                            repository: repository];
+  [[NotificationControllerFactory sharedController] showNotificationWithError: @"Cached copy was deleted and can't be restored."
+                                                                   repository: repository];
 }
 
 @end

--- a/Classes/GrowlController.h
+++ b/Classes/GrowlController.h
@@ -18,7 +18,6 @@ extern NSString *OtherMessageGrowl;
 
 @property RepositoryListController *repositoryListController;
 
-+ (GrowlController *) sharedController;
 + (BOOL) growlDetected;
 
 @end

--- a/Classes/GrowlController.h
+++ b/Classes/GrowlController.h
@@ -6,6 +6,7 @@
 // -------------------------------------------------------
 
 #import <Growl/GrowlApplicationBridge.h>
+#import "NotificationController.h"
 
 @class Commit;
 @class Repository;
@@ -13,19 +14,11 @@
 
 extern NSString *OtherMessageGrowl;
 
-@interface GrowlController : NSObject <GrowlApplicationBridgeDelegate>
+@interface GrowlController : NSObject <GrowlApplicationBridgeDelegate, NotificationController>
 
 @property RepositoryListController *repositoryListController;
 
 + (GrowlController *) sharedController;
 + (BOOL) growlDetected;
-
-- (void) showGrowlWithCommit: (Commit *) commit;
-- (void) showGrowlWithCommitGroup: (NSArray *) commits includesAllCommits: (BOOL) includesAll;
-- (void) showGrowlWithCommitGroupIncludingAllCommits: (NSArray *) commits;
-- (void) showGrowlWithCommitGroupIncludingSomeCommits: (NSArray *) commits;
-
-- (void) showGrowlWithError: (NSString *) message repository: (Repository *) repository;
-- (void) showGrowlWithTitle: (NSString *) title message: (NSString *) message type: (NSString *) type;
 
 @end

--- a/Classes/GrowlController.m
+++ b/Classes/GrowlController.m
@@ -19,14 +19,6 @@ NSString *OtherMessageGrowl           = @"Other message";
 
 @implementation GrowlController
 
-+ (GrowlController *) sharedController {
-  static GrowlController *instance = nil;
-  if (!instance) {
-    instance = [[GrowlController alloc] init];
-  }
-  return instance;
-}
-
 + (BOOL) growlDetected {
   return [GrowlApplicationBridge isGrowlRunning];
 }

--- a/Classes/GrowlController.m
+++ b/Classes/GrowlController.m
@@ -31,7 +31,7 @@ NSString *OtherMessageGrowl           = @"Other message";
   return self;
 }
 
-- (void) showGrowlWithCommit: (Commit *) commit {
+- (void) showNotificationWithCommit: (Commit *) commit {
   BOOL sticky = [GitifierDefaults boolForKey: StickyNotificationsKey];
   NSDictionary *commitData = @{@"commit": [commit toDictionary], @"repository": commit.repository.url};
 
@@ -44,7 +44,7 @@ NSString *OtherMessageGrowl           = @"Other message";
                              clickContext: commitData];
 }
 
-- (void) showGrowlWithCommitGroup: (NSArray *) commits includesAllCommits: (BOOL) includesAll {
+- (void) showNotificationWithCommitGroup: (NSArray *) commits includesAllCommits: (BOOL) includesAll {
   BOOL sticky = [GitifierDefaults boolForKey: StickyNotificationsKey];
   NSArray *authorNames = [commits valueForKeyPath: @"@distinctUnionOfObjects.authorName"];
   NSString *authorList = [authorNames componentsJoinedByString: @", "];
@@ -59,15 +59,15 @@ NSString *OtherMessageGrowl           = @"Other message";
                              clickContext: nil];
 }
 
-- (void) showGrowlWithCommitGroupIncludingAllCommits: (NSArray *) commits {
-  [self showGrowlWithCommitGroup: commits includesAllCommits: YES];
+- (void) showNotificationWithCommitGroupIncludingAllCommits: (NSArray *) commits {
+  [self showNotificationWithCommitGroup: commits includesAllCommits: YES];
 }
 
-- (void) showGrowlWithCommitGroupIncludingSomeCommits: (NSArray *) commits {
-  [self showGrowlWithCommitGroup: commits includesAllCommits: NO];
+- (void) showNotificationWithCommitGroupIncludingSomeCommits: (NSArray *) commits {
+  [self showNotificationWithCommitGroup: commits includesAllCommits: NO];
 }
 
-- (void) showGrowlWithError: (NSString *) message repository: (Repository *) repository {
+- (void) showNotificationWithError: (NSString *) message repository: (Repository *) repository {
   NSString *title;
   if (repository) {
     NSLog(@"Error in %@: %@", repository.name, message);
@@ -77,10 +77,10 @@ NSString *OtherMessageGrowl           = @"Other message";
     title = @"Error";
   }
 
-  [self showGrowlWithTitle: title message: message type: RepositoryUpdateFailedGrowl];
+  [self showNotificationWithTitle: title message: message type: RepositoryUpdateFailedGrowl];
 }
 
-- (void) showGrowlWithTitle: (NSString *) title message: (NSString *) message type: (NSString *) type {
+- (void) showNotificationWithTitle: (NSString *) title message: (NSString *) message type: (NSString *) type {
   [GrowlApplicationBridge notifyWithTitle: title
                               description: message
                          notificationName: type

--- a/Classes/GrowlController.m
+++ b/Classes/GrowlController.m
@@ -6,11 +6,10 @@
 // -------------------------------------------------------
 
 #import "Commit.h"
-#import "CommitWindowController.h"
 #import "Defaults.h"
 #import "GrowlController.h"
 #import "Repository.h"
-#import "RepositoryListController.h"
+#import "NotificationControllerClickHandler.h"
 
 NSString *CommitReceivedGrowl         = @"Commit received";
 NSString *RepositoryUpdateFailedGrowl = @"Repository update failed";
@@ -104,26 +103,9 @@ NSString *OtherMessageGrowl           = @"Other message";
   id date = clickContext[@"commit"][@"date"];
   if ([date isKindOfClass: [NSString class]]) return;
 
-  BOOL shouldShowDiffs = [GitifierDefaults boolForKey: ShowDiffWindowKey];
-  BOOL shouldOpenInBrowser = [GitifierDefaults boolForKey: OpenDiffInBrowserKey];
-  
-  if (clickContext && shouldShowDiffs) {
-    NSString *url = clickContext[@"repository"];
-    NSDictionary *commitHash = clickContext[@"commit"];
-    Repository *repository = [self.repositoryListController findByUrl: url];
-
-    if (repository) {
-      Commit *commit = [Commit commitFromDictionary: commitHash];
-      commit.repository = repository;
-      NSURL *webUrl = [repository webUrlForCommit: commit];
-
-      if (webUrl && shouldOpenInBrowser) {
-        [[NSWorkspace sharedWorkspace] openURL: webUrl];
-      } else {
-        [[[CommitWindowController alloc] initWithCommit: commit] show];
-      }
-    }
-  }
+  NotificationControllerClickHandler *handler = [NotificationControllerClickHandler new];
+  handler.repositoryListController = self.repositoryListController;
+  [handler handleClickWithDictionary: clickContext];
 }
 
 @end

--- a/Classes/NewRepositoryDialogController.m
+++ b/Classes/NewRepositoryDialogController.m
@@ -9,6 +9,7 @@
 #import "NewRepositoryDialogController.h"
 #import "Repository.h"
 #import "RepositoryListController.h"
+#import "NotificationControllerFactory.h"
 
 @implementation NewRepositoryDialogController {
   NSTimer *slowCloneTimer;
@@ -129,7 +130,7 @@
   [self hideNewRepositorySheet];
 
   if (waitingForSlowClone) {
-    GrowlController *growl = [GrowlController sharedController];
+    id<NotificationController>growl = [NotificationControllerFactory sharedController];
     [growl showGrowlWithTitle: @"Repository cloned"
                       message: PSFormat(@"Repository at %@ has been successfully added to Gitifier.", repository.url)
                          type: OtherMessageGrowl];

--- a/Classes/NewRepositoryDialogController.m
+++ b/Classes/NewRepositoryDialogController.m
@@ -131,9 +131,8 @@
 
   if (waitingForSlowClone) {
     id<NotificationController>growl = [NotificationControllerFactory sharedController];
-    [growl showGrowlWithTitle: @"Repository cloned"
-                      message: PSFormat(@"Repository at %@ has been successfully added to Gitifier.", repository.url)
-                         type: OtherMessageGrowl];
+    [growl showNotificationWithTitle: @"Repository cloned"
+                             message: PSFormat(@"Repository at %@ has been successfully added to Gitifier.", repository.url) type: OtherMessageGrowl];
   }
 
   [self unlockDialog];

--- a/Classes/NotificationCenterController.h
+++ b/Classes/NotificationCenterController.h
@@ -1,0 +1,10 @@
+#import "NotificationController.h"
+
+/** Implementation of the NotificationCenter protocol for Mountain Lion's notification center. */
+@interface NotificationCenterController : NSObject<NotificationController>
+
+@property RepositoryListController *repositoryListController;
+
++ (BOOL) notificationCenterDetected;
+
+@end

--- a/Classes/NotificationCenterController.m
+++ b/Classes/NotificationCenterController.m
@@ -82,6 +82,8 @@
   NotificationControllerClickHandler *handler = [NotificationControllerClickHandler new];
   handler.repositoryListController = self.repositoryListController;
   [handler handleClickWithDictionary: notification.userInfo];
+
+  [center removeDeliveredNotification: notification];
 }
 
 @end

--- a/Classes/NotificationCenterController.m
+++ b/Classes/NotificationCenterController.m
@@ -1,0 +1,67 @@
+#import "NotificationCenterController.h"
+
+#import "Commit.h"
+#import "Repository.h"
+#import "PSMacros.h"
+
+@implementation NotificationCenterController
+
++ (BOOL) notificationCenterDetected {
+  return NSClassFromString(@"NSUserNotification") != nil;
+}
+
+- (void) showNotificationWithCommit: (Commit *) commit {
+  [self showNotificationWithTitle:commit.repository.name
+                         subtitle:commit.authorName
+                          message:commit.subject];
+}
+
+- (void) showNotificationWithCommitGroup: (NSArray *) commits includesAllCommits: (BOOL) includesAll {
+  NSArray *authorNames = [commits valueForKeyPath: @"@distinctUnionOfObjects.authorName"];
+  NSString *authorList = [authorNames componentsJoinedByString: @", "];
+  NSString *message = includesAll ? @"%d commits received" : @"… and %d other commits";
+
+  [self showNotificationWithTitle:PSFormat(message, commits.count)
+                         subtitle:nil
+                          message:PSFormat(@"Author%@: %@", (authorNames.count > 1) ? @"s" : @"", authorList)];
+}
+
+- (void) showNotificationWithCommitGroupIncludingAllCommits: (NSArray *) commits {
+  [self showNotificationWithCommitGroup: commits includesAllCommits: YES];
+}
+
+- (void) showNotificationWithCommitGroupIncludingSomeCommits: (NSArray *) commits {
+  [self showNotificationWithCommitGroup: commits includesAllCommits: NO];
+}
+
+- (void) showNotificationWithError: (NSString *) message repository: (Repository *) repository {
+  NSString *title;
+  if (repository) {
+    NSLog(@"Error in %@: %@", repository.name, message);
+    title = PSFormat(@"Error in %@", repository.name);
+  } else {
+    NSLog(@"Error: %@", message);
+    title = @"Error";
+  }
+
+  [self showNotificationWithTitle: title subtitle: nil message: message];
+}
+
+- (void) showNotificationWithTitle: (NSString *) title message: (NSString *) message type: (NSString *) type {
+  [self showNotificationWithTitle: title
+                         subtitle: nil
+                          message: message];
+}
+
+- (void) showNotificationWithTitle: (NSString *) title
+                          subtitle: (NSString *) subtitle
+                           message: (NSString *) message {
+
+  NSUserNotification *notification = [[NSUserNotification alloc] init];
+  notification.title = title;
+  notification.subtitle = subtitle;
+  notification.informativeText = message;
+  [[NSUserNotificationCenter defaultUserNotificationCenter] deliverNotification:notification];
+}
+
+@end

--- a/Classes/NotificationCenterController.m
+++ b/Classes/NotificationCenterController.m
@@ -36,9 +36,9 @@
   NSString *authorList = [authorNames componentsJoinedByString: @", "];
   NSString *message = includesAll ? @"%d commits received" : @"… and %d other commits";
 
-  [self showNotificationWithTitle:PSFormat(message, commits.count)
-                         subtitle:nil
-                          message:PSFormat(@"Author%@: %@", (authorNames.count > 1) ? @"s" : @"", authorList)
+  [self showNotificationWithTitle:((Commit *)commits[0]).repository.name
+                         subtitle:PSFormat(authorList)
+                          message:PSFormat(message, commits.count)
                              info:nil];
 }
 
@@ -51,16 +51,13 @@
 }
 
 - (void) showNotificationWithError: (NSString *) message repository: (Repository *) repository {
-  NSString *title;
   if (repository) {
     NSLog(@"Error in %@: %@", repository.name, message);
-    title = PSFormat(@"Error in %@", repository.name);
   } else {
     NSLog(@"Error: %@", message);
-    title = @"Error";
   }
 
-  [self showNotificationWithTitle: title subtitle: nil message: message info: nil];
+  [self showNotificationWithTitle: @"Error" subtitle: repository.name message: message info: nil];
 }
 
 - (void) showNotificationWithTitle: (NSString *) title message: (NSString *) message type: (NSString *) type {

--- a/Classes/NotificationController.h
+++ b/Classes/NotificationController.h
@@ -1,0 +1,17 @@
+@class Commit;
+@class Repository;
+@class RepositoryListController;
+
+@protocol NotificationController <NSObject>
+
+- (void)setRepositoryListController: (RepositoryListController *)repositoryListController;
+
+- (void) showGrowlWithCommit: (Commit *) commit;
+- (void) showGrowlWithCommitGroup: (NSArray *) commits includesAllCommits: (BOOL) includesAll;
+- (void) showGrowlWithCommitGroupIncludingAllCommits: (NSArray *) commits;
+- (void) showGrowlWithCommitGroupIncludingSomeCommits: (NSArray *) commits;
+
+- (void) showGrowlWithError: (NSString *) message repository: (Repository *) repository;
+- (void) showGrowlWithTitle: (NSString *) title message: (NSString *) message type: (NSString *) type;
+
+@end

--- a/Classes/NotificationController.h
+++ b/Classes/NotificationController.h
@@ -6,12 +6,12 @@
 
 - (void)setRepositoryListController: (RepositoryListController *)repositoryListController;
 
-- (void) showGrowlWithCommit: (Commit *) commit;
-- (void) showGrowlWithCommitGroup: (NSArray *) commits includesAllCommits: (BOOL) includesAll;
-- (void) showGrowlWithCommitGroupIncludingAllCommits: (NSArray *) commits;
-- (void) showGrowlWithCommitGroupIncludingSomeCommits: (NSArray *) commits;
+- (void) showNotificationWithCommit: (Commit *) commit;
+- (void) showNotificationWithCommitGroup: (NSArray *) commits includesAllCommits: (BOOL) includesAll;
+- (void) showNotificationWithCommitGroupIncludingAllCommits: (NSArray *) commits;
+- (void) showNotificationWithCommitGroupIncludingSomeCommits: (NSArray *) commits;
 
-- (void) showGrowlWithError: (NSString *) message repository: (Repository *) repository;
-- (void) showGrowlWithTitle: (NSString *) title message: (NSString *) message type: (NSString *) type;
+- (void) showNotificationWithError: (NSString *) message repository: (Repository *) repository;
+- (void) showNotificationWithTitle: (NSString *) title message: (NSString *) message type: (NSString *) type;
 
 @end

--- a/Classes/NotificationControllerClickHandler.h
+++ b/Classes/NotificationControllerClickHandler.h
@@ -1,0 +1,9 @@
+@class RepositoryListController;
+
+@interface NotificationControllerClickHandler : NSObject
+
+@property RepositoryListController *repositoryListController;
+
+- (void) handleClickWithDictionary: (NSDictionary *) dictionary;
+
+@end

--- a/Classes/NotificationControllerClickHandler.m
+++ b/Classes/NotificationControllerClickHandler.m
@@ -1,0 +1,34 @@
+#import "NotificationControllerClickHandler.h"
+#import "Defaults.h"
+#import "Repository.h"
+#import "RepositoryListController.h"
+#import "Commit.h"
+#import "CommitWindowController.h"
+
+@implementation NotificationControllerClickHandler
+
+- (void) handleClickWithDictionary: (NSDictionary *) clickContext {
+
+  BOOL shouldShowDiffs = [GitifierDefaults boolForKey: ShowDiffWindowKey];
+  BOOL shouldOpenInBrowser = [GitifierDefaults boolForKey: OpenDiffInBrowserKey];
+
+  if (clickContext && shouldShowDiffs) {
+    NSString *url = clickContext[@"repository"];
+    NSDictionary *commitHash = clickContext[@"commit"];
+    Repository *repository = [self.repositoryListController findByUrl: url];
+
+    if (repository) {
+      Commit *commit = [Commit commitFromDictionary: commitHash];
+      commit.repository = repository;
+      NSURL *webUrl = [repository webUrlForCommit: commit];
+
+      if (webUrl && shouldOpenInBrowser) {
+        [[NSWorkspace sharedWorkspace] openURL: webUrl];
+      } else {
+        [[[CommitWindowController alloc] initWithCommit: commit] show];
+      }
+    }
+  }
+}
+
+@end

--- a/Classes/NotificationControllerFactory.h
+++ b/Classes/NotificationControllerFactory.h
@@ -1,0 +1,7 @@
+@protocol NotificationController;
+
+@interface NotificationControllerFactory : NSObject
+
++ (id<NotificationController>) sharedController;
+
+@end

--- a/Classes/NotificationControllerFactory.m
+++ b/Classes/NotificationControllerFactory.m
@@ -1,0 +1,14 @@
+#import "NotificationControllerFactory.h"
+#import "GrowlController.h"
+
+@implementation NotificationControllerFactory
+
++ (id<NotificationController>) sharedController {
+  static GrowlController *instance = nil;
+  if (!instance) {
+    instance = [[GrowlController alloc] init];
+  }
+  return instance;
+}
+
+@end

--- a/Classes/NotificationControllerFactory.m
+++ b/Classes/NotificationControllerFactory.m
@@ -1,14 +1,24 @@
 #import "NotificationControllerFactory.h"
 #import "GrowlController.h"
+#import "NotificationCenterController.h"
 
 @implementation NotificationControllerFactory
 
 + (id<NotificationController>) sharedController {
-  static GrowlController *instance = nil;
+  static id<NotificationController> instance = nil;
   if (!instance) {
-    instance = [[GrowlController alloc] init];
+    if ([self isUseNotificationCenter]) {
+      instance = [[NotificationCenterController alloc] init];
+    } else {
+      instance = [[GrowlController alloc] init];
+    }
   }
   return instance;
+}
+
++ (BOOL) isUseNotificationCenter {
+  return [NotificationCenterController notificationCenterDetected]
+            && ![GrowlController growlDetected];
 }
 
 @end

--- a/Classes/Repository.m
+++ b/Classes/Repository.m
@@ -11,6 +11,7 @@
 #import "Git.h"
 #import "GrowlController.h"
 #import "Repository.h"
+#import "NotificationControllerFactory.h"
 
 static NSString *nameRegexp = @"[\\p{Ll}\\p{Lu}\\p{Lt}\\p{Lo}\\p{Nd}\\-\\.]+";
 static NSString *commitRangeRegexp = @"[0-9a-f]+\\.\\.[0-9a-f]+";
@@ -130,7 +131,7 @@ static NSString *commitRangeRegexp = @"[0-9a-f]+\\.\\.[0-9a-f]+";
         [self clone];
       }
     } else {
-      [[GrowlController sharedController] showGrowlWithError: @"Can't fetch repository." repository: self];
+      [[NotificationControllerFactory sharedController] showGrowlWithError: @"Can't fetch repository." repository: self];
     }
   }
 }
@@ -184,8 +185,8 @@ static NSString *commitRangeRegexp = @"[0-9a-f]+\\.\\.[0-9a-f]+";
   } else if (status != UnavailableRepository) {
     status = UnavailableRepository;
     NSString *truncated = (output.length > 100) ? PSFormat(@"%@...", [output substringToIndex: 100]) : output;
-    [[GrowlController sharedController] showGrowlWithError: PSFormat(@"Command %@ failed: %@", command, truncated)
-                                                repository: self];
+    [[NotificationControllerFactory sharedController] showGrowlWithError: PSFormat(@"Command %@ failed: %@", command, truncated)
+                                                              repository: self];
   }
 }
 

--- a/Classes/Repository.m
+++ b/Classes/Repository.m
@@ -131,7 +131,7 @@ static NSString *commitRangeRegexp = @"[0-9a-f]+\\.\\.[0-9a-f]+";
         [self clone];
       }
     } else {
-      [[NotificationControllerFactory sharedController] showGrowlWithError: @"Can't fetch repository." repository: self];
+      [[NotificationControllerFactory sharedController] showNotificationWithError: @"Can't fetch repository." repository: self];
     }
   }
 }
@@ -185,8 +185,7 @@ static NSString *commitRangeRegexp = @"[0-9a-f]+\\.\\.[0-9a-f]+";
   } else if (status != UnavailableRepository) {
     status = UnavailableRepository;
     NSString *truncated = (output.length > 100) ? PSFormat(@"%@...", [output substringToIndex: 100]) : output;
-    [[NotificationControllerFactory sharedController] showGrowlWithError: PSFormat(@"Command %@ failed: %@", command, truncated)
-                                                              repository: self];
+    [[NotificationControllerFactory sharedController] showNotificationWithError: PSFormat(@"Command %@ failed: %@", command, truncated) repository: self];
   }
 }
 

--- a/Gitifier.xcodeproj/project.pbxproj
+++ b/Gitifier.xcodeproj/project.pbxproj
@@ -7,7 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1AA1001A46D8D6988DF07147 /* NotificationControllerClickHandler.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1AA1023C7632610686E5A0BC /* NotificationControllerClickHandler.h */; };
 		1AA10311942D30BBB3A4D751 /* NotificationControllerFactory.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1AA10F4496A269E62D879428 /* NotificationControllerFactory.h */; };
+		1AA10617361FC302CADB032C /* NotificationControllerClickHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA10A2B7740270E206877FA /* NotificationControllerClickHandler.m */; };
 		1AA10A1C9340DF29B915176E /* NotificationControllerFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA10E7ECADAF2AB34CA8A07 /* NotificationControllerFactory.m */; };
 		1AA10B4F33421FB6FDCD5230 /* NotificationCenterController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA10F4D5032E881AB4084C9 /* NotificationCenterController.m */; };
 		1AA10FB355EFA2C9CC00F79D /* NotificationCenterController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1AA1001750E0E2483977F77F /* NotificationCenterController.h */; };
@@ -94,6 +96,7 @@
 				1AA10FDEFBA4D0254DF5E85E /* NotificationController.h in CopyFiles */,
 				1AA10311942D30BBB3A4D751 /* NotificationControllerFactory.h in CopyFiles */,
 				1AA10FB355EFA2C9CC00F79D /* NotificationCenterController.h in CopyFiles */,
+				1AA1001A46D8D6988DF07147 /* NotificationControllerClickHandler.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -103,6 +106,8 @@
 		089C165DFE840E0CC02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		1AA1001750E0E2483977F77F /* NotificationCenterController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationCenterController.h; sourceTree = "<group>"; };
+		1AA1023C7632610686E5A0BC /* NotificationControllerClickHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationControllerClickHandler.h; sourceTree = "<group>"; };
+		1AA10A2B7740270E206877FA /* NotificationControllerClickHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NotificationControllerClickHandler.m; sourceTree = "<group>"; };
 		1AA10E7ECADAF2AB34CA8A07 /* NotificationControllerFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NotificationControllerFactory.m; sourceTree = "<group>"; };
 		1AA10E87E1D6C1F9649F47D2 /* NotificationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationController.h; sourceTree = "<group>"; };
 		1AA10F4496A269E62D879428 /* NotificationControllerFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationControllerFactory.h; sourceTree = "<group>"; };
@@ -467,6 +472,8 @@
 				1AA10F4496A269E62D879428 /* NotificationControllerFactory.h */,
 				1AA10F4D5032E881AB4084C9 /* NotificationCenterController.m */,
 				1AA1001750E0E2483977F77F /* NotificationCenterController.h */,
+				1AA10A2B7740270E206877FA /* NotificationControllerClickHandler.m */,
+				1AA1023C7632610686E5A0BC /* NotificationControllerClickHandler.h */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -612,6 +619,7 @@
 				58A181FA1484311B00835E97 /* NotificationsPanelController.m in Sources */,
 				1AA10A1C9340DF29B915176E /* NotificationControllerFactory.m in Sources */,
 				1AA10B4F33421FB6FDCD5230 /* NotificationCenterController.m in Sources */,
+				1AA10617361FC302CADB032C /* NotificationControllerClickHandler.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Gitifier.xcodeproj/project.pbxproj
+++ b/Gitifier.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1AA10311942D30BBB3A4D751 /* NotificationControllerFactory.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1AA10F4496A269E62D879428 /* NotificationControllerFactory.h */; };
+		1AA10A1C9340DF29B915176E /* NotificationControllerFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA10E7ECADAF2AB34CA8A07 /* NotificationControllerFactory.m */; };
 		1AA10FDEFBA4D0254DF5E85E /* NotificationController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1AA10E87E1D6C1F9649F47D2 /* NotificationController.h */; };
 		1DDD58160DA1D0A300B32029 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1DDD58140DA1D0A300B32029 /* MainMenu.xib */; };
 		581C9E91127E046D003ECF6A /* PasswordHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 588ACB03124AAE5E004F3785 /* PasswordHelper.m */; };
@@ -88,6 +90,7 @@
 				58DEC1051242C3AD00DE7C7E /* Growl.framework in CopyFiles */,
 				588ACDE3124C15A0004F3785 /* Sparkle.framework in CopyFiles */,
 				1AA10FDEFBA4D0254DF5E85E /* NotificationController.h in CopyFiles */,
+				1AA10311942D30BBB3A4D751 /* NotificationControllerFactory.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -96,7 +99,9 @@
 /* Begin PBXFileReference section */
 		089C165DFE840E0CC02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		1AA10E7ECADAF2AB34CA8A07 /* NotificationControllerFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NotificationControllerFactory.m; sourceTree = "<group>"; };
 		1AA10E87E1D6C1F9649F47D2 /* NotificationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationController.h; sourceTree = "<group>"; };
+		1AA10F4496A269E62D879428 /* NotificationControllerFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationControllerFactory.h; sourceTree = "<group>"; };
 		1DDD58150DA1D0A300B32029 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		256AC3F00F4B6AF500CF3369 /* Gitifier_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Gitifier_Prefix.pch; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -453,6 +458,8 @@
 				58DEC8341246C6B300DE7C7E /* Utils.h */,
 				58DEC8351246C6B300DE7C7E /* Utils.m */,
 				1AA10E87E1D6C1F9649F47D2 /* NotificationController.h */,
+				1AA10E7ECADAF2AB34CA8A07 /* NotificationControllerFactory.m */,
+				1AA10F4496A269E62D879428 /* NotificationControllerFactory.h */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -596,6 +603,7 @@
 				584ED6FD13B37F650085E65C /* RepositoriesPanelController.m in Sources */,
 				584ED70013B37F780085E65C /* AboutPanelController.m in Sources */,
 				58A181FA1484311B00835E97 /* NotificationsPanelController.m in Sources */,
+				1AA10A1C9340DF29B915176E /* NotificationControllerFactory.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Gitifier.xcodeproj/project.pbxproj
+++ b/Gitifier.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		1AA10311942D30BBB3A4D751 /* NotificationControllerFactory.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1AA10F4496A269E62D879428 /* NotificationControllerFactory.h */; };
 		1AA10A1C9340DF29B915176E /* NotificationControllerFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA10E7ECADAF2AB34CA8A07 /* NotificationControllerFactory.m */; };
+		1AA10B4F33421FB6FDCD5230 /* NotificationCenterController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA10F4D5032E881AB4084C9 /* NotificationCenterController.m */; };
+		1AA10FB355EFA2C9CC00F79D /* NotificationCenterController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1AA1001750E0E2483977F77F /* NotificationCenterController.h */; };
 		1AA10FDEFBA4D0254DF5E85E /* NotificationController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1AA10E87E1D6C1F9649F47D2 /* NotificationController.h */; };
 		1DDD58160DA1D0A300B32029 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1DDD58140DA1D0A300B32029 /* MainMenu.xib */; };
 		581C9E91127E046D003ECF6A /* PasswordHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 588ACB03124AAE5E004F3785 /* PasswordHelper.m */; };
@@ -91,6 +93,7 @@
 				588ACDE3124C15A0004F3785 /* Sparkle.framework in CopyFiles */,
 				1AA10FDEFBA4D0254DF5E85E /* NotificationController.h in CopyFiles */,
 				1AA10311942D30BBB3A4D751 /* NotificationControllerFactory.h in CopyFiles */,
+				1AA10FB355EFA2C9CC00F79D /* NotificationCenterController.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -99,9 +102,11 @@
 /* Begin PBXFileReference section */
 		089C165DFE840E0CC02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		1AA1001750E0E2483977F77F /* NotificationCenterController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationCenterController.h; sourceTree = "<group>"; };
 		1AA10E7ECADAF2AB34CA8A07 /* NotificationControllerFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NotificationControllerFactory.m; sourceTree = "<group>"; };
 		1AA10E87E1D6C1F9649F47D2 /* NotificationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationController.h; sourceTree = "<group>"; };
 		1AA10F4496A269E62D879428 /* NotificationControllerFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationControllerFactory.h; sourceTree = "<group>"; };
+		1AA10F4D5032E881AB4084C9 /* NotificationCenterController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NotificationCenterController.m; sourceTree = "<group>"; };
 		1DDD58150DA1D0A300B32029 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		256AC3F00F4B6AF500CF3369 /* Gitifier_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Gitifier_Prefix.pch; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -460,6 +465,8 @@
 				1AA10E87E1D6C1F9649F47D2 /* NotificationController.h */,
 				1AA10E7ECADAF2AB34CA8A07 /* NotificationControllerFactory.m */,
 				1AA10F4496A269E62D879428 /* NotificationControllerFactory.h */,
+				1AA10F4D5032E881AB4084C9 /* NotificationCenterController.m */,
+				1AA1001750E0E2483977F77F /* NotificationCenterController.h */,
 			);
 			path = Classes;
 			sourceTree = "<group>";
@@ -604,6 +611,7 @@
 				584ED70013B37F780085E65C /* AboutPanelController.m in Sources */,
 				58A181FA1484311B00835E97 /* NotificationsPanelController.m in Sources */,
 				1AA10A1C9340DF29B915176E /* NotificationControllerFactory.m in Sources */,
+				1AA10B4F33421FB6FDCD5230 /* NotificationCenterController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Gitifier.xcodeproj/project.pbxproj
+++ b/Gitifier.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1AA10FDEFBA4D0254DF5E85E /* NotificationController.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 1AA10E87E1D6C1F9649F47D2 /* NotificationController.h */; };
 		1DDD58160DA1D0A300B32029 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1DDD58140DA1D0A300B32029 /* MainMenu.xib */; };
 		581C9E91127E046D003ECF6A /* PasswordHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 588ACB03124AAE5E004F3785 /* PasswordHelper.m */; };
 		581C9E9E127E050A003ECF6A /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 588ACB14124AAF91004F3785 /* Security.framework */; };
@@ -86,6 +87,7 @@
 			files = (
 				58DEC1051242C3AD00DE7C7E /* Growl.framework in CopyFiles */,
 				588ACDE3124C15A0004F3785 /* Sparkle.framework in CopyFiles */,
+				1AA10FDEFBA4D0254DF5E85E /* NotificationController.h in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,6 +96,7 @@
 /* Begin PBXFileReference section */
 		089C165DFE840E0CC02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		1AA10E87E1D6C1F9649F47D2 /* NotificationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationController.h; sourceTree = "<group>"; };
 		1DDD58150DA1D0A300B32029 /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		256AC3F00F4B6AF500CF3369 /* Gitifier_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Gitifier_Prefix.pch; sourceTree = "<group>"; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -449,6 +452,7 @@
 				58DEC8331246C6B300DE7C7E /* StatusBarController.m */,
 				58DEC8341246C6B300DE7C7E /* Utils.h */,
 				58DEC8351246C6B300DE7C7E /* Utils.m */,
+				1AA10E87E1D6C1F9649F47D2 /* NotificationController.h */,
 			);
 			path = Classes;
 			sourceTree = "<group>";

--- a/NotificationsPreferencesPanel.xib
+++ b/NotificationsPreferencesPanel.xib
@@ -1,28 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">1070</int>
-		<string key="IBDocument.SystemVersion">11C74</string>
-		<string key="IBDocument.InterfaceBuilderVersion">1938</string>
-		<string key="IBDocument.AppKitVersion">1138.23</string>
-		<string key="IBDocument.HIToolboxVersion">567.00</string>
+		<int key="IBDocument.SystemTarget">1080</int>
+		<string key="IBDocument.SystemVersion">12C60</string>
+		<string key="IBDocument.InterfaceBuilderVersion">2844</string>
+		<string key="IBDocument.AppKitVersion">1187.34</string>
+		<string key="IBDocument.HIToolboxVersion">625.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.CocoaPlugin</string>
-			<string key="NS.object.0">1938</string>
+			<string key="NS.object.0">2844</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
-			<string>NSTextField</string>
-			<string>NSCustomObject</string>
 			<string>NSBox</string>
+			<string>NSButton</string>
+			<string>NSButtonCell</string>
+			<string>NSCustomObject</string>
+			<string>NSCustomView</string>
+			<string>NSImageCell</string>
 			<string>NSImageView</string>
 			<string>NSNumberFormatter</string>
-			<string>NSCustomView</string>
-			<string>NSButtonCell</string>
-			<string>NSImageCell</string>
-			<string>NSButton</string>
-			<string>NSUserDefaultsController</string>
+			<string>NSTextField</string>
 			<string>NSTextFieldCell</string>
+			<string>NSUserDefaultsController</string>
 		</object>
 		<object class="NSArray" key="IBDocument.PluginDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -59,9 +59,10 @@
 								<string key="NSFrame">{{0, 18}, {485, 5}}</string>
 								<reference key="NSSuperview" ref="99672514"/>
 								<reference key="NSWindow"/>
+								<reference key="NSNextKeyView" ref="996414272"/>
 								<string key="NSOffsets">{0, 0}</string>
 								<object class="NSTextFieldCell" key="NSTitleCell">
-									<int key="NSCellFlags">67239424</int>
+									<int key="NSCellFlags">67108864</int>
 									<int key="NSCellFlags2">0</int>
 									<string key="NSContents">Box</string>
 									<object class="NSFont" key="NSSupport" id="1057182896">
@@ -98,19 +99,20 @@
 								<string key="NSReuseIdentifierKey">_NS:687</string>
 								<bool key="NSEnabled">YES</bool>
 								<object class="NSButtonCell" key="NSCell" id="167543215">
-									<int key="NSCellFlags">67239424</int>
+									<int key="NSCellFlags">67108864</int>
 									<int key="NSCellFlags2">134217728</int>
 									<string key="NSContents">Get Growl from Mac App Store</string>
 									<reference key="NSSupport" ref="1057182896"/>
 									<string key="NSCellIdentifier">_NS:687</string>
 									<reference key="NSControlView" ref="317235119"/>
-									<int key="NSButtonFlags">-2038284033</int>
+									<int key="NSButtonFlags">-2038284288</int>
 									<int key="NSButtonFlags2">129</int>
 									<string key="NSAlternateContents"/>
 									<string key="NSKeyEquivalent"/>
 									<int key="NSPeriodicDelay">200</int>
 									<int key="NSPeriodicInterval">25</int>
 								</object>
+								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 							</object>
 							<object class="NSTextField" id="41113232">
 								<reference key="NSNextResponder" ref="99672514"/>
@@ -122,7 +124,7 @@
 								<string key="NSReuseIdentifierKey">_NS:3944</string>
 								<bool key="NSEnabled">YES</bool>
 								<object class="NSTextFieldCell" key="NSCell" id="913806574">
-									<int key="NSCellFlags">67239424</int>
+									<int key="NSCellFlags">67108864</int>
 									<int key="NSCellFlags2">1346371584</int>
 									<string key="NSContents">Gitifier uses software called Growl to show commit notifications. Installing Growl is not required, but doing so will give you more control over the appearance and behavior of notifications.</string>
 									<reference key="NSSupport" ref="1057182896"/>
@@ -147,6 +149,7 @@
 										</object>
 									</object>
 								</object>
+								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 							</object>
 							<object class="NSTextField" id="477890949">
 								<reference key="NSNextResponder" ref="99672514"/>
@@ -158,7 +161,7 @@
 								<string key="NSReuseIdentifierKey">_NS:3944</string>
 								<bool key="NSEnabled">YES</bool>
 								<object class="NSTextFieldCell" key="NSCell" id="1055951630">
-									<int key="NSCellFlags">68288064</int>
+									<int key="NSCellFlags">68157504</int>
 									<int key="NSCellFlags2">272630784</int>
 									<string key="NSContents">Growl not detected</string>
 									<object class="NSFont" key="NSSupport">
@@ -171,6 +174,7 @@
 									<reference key="NSBackgroundColor" ref="199757900"/>
 									<reference key="NSTextColor" ref="122213290"/>
 								</object>
+								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 							</object>
 							<object class="NSImageView" id="1063828244">
 								<reference key="NSNextResponder" ref="99672514"/>
@@ -194,19 +198,19 @@
 								<string key="NSReuseIdentifierKey">_NS:2141</string>
 								<bool key="NSEnabled">YES</bool>
 								<object class="NSImageCell" key="NSCell" id="702343376">
-									<int key="NSCellFlags">67239424</int>
+									<int key="NSCellFlags">134217728</int>
 									<int key="NSCellFlags2">33554432</int>
 									<object class="NSCustomResource" key="NSContents">
 										<string key="NSClassName">NSImage</string>
 										<string key="NSResourceName">growl_icon</string>
 									</object>
-									<reference key="NSSupport" ref="1057182896"/>
 									<string key="NSCellIdentifier">_NS:2141</string>
 									<int key="NSAlign">0</int>
 									<int key="NSScale">0</int>
 									<int key="NSStyle">0</int>
 									<bool key="NSAnimates">NO</bool>
 								</object>
+								<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 								<bool key="NSEditable">YES</bool>
 							</object>
 						</object>
@@ -227,7 +231,7 @@
 						<string key="NSReuseIdentifierKey">_NS:3944</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="996924731">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">notifications</string>
 							<reference key="NSSupport" ref="1057182896"/>
@@ -236,6 +240,7 @@
 							<reference key="NSBackgroundColor" ref="199757900"/>
 							<reference key="NSTextColor" ref="122213290"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="328560324">
 						<reference key="NSNextResponder" ref="185234335"/>
@@ -247,7 +252,7 @@
 						<string key="NSReuseIdentifierKey">_NS:903</string>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="259720189">
-							<int key="NSCellFlags">-1804468671</int>
+							<int key="NSCellFlags">-1804599231</int>
 							<int key="NSCellFlags2">272630784</int>
 							<real value="123" key="NSContents"/>
 							<reference key="NSSupport" ref="1057182896"/>
@@ -265,7 +270,7 @@
 										<string>nilSymbol</string>
 										<string>positiveInfinitySymbol</string>
 									</object>
-									<object class="NSMutableArray" key="dict.values">
+									<object class="NSArray" key="dict.values">
 										<bool key="EncodedWithXMLCoder">YES</bool>
 										<boolean value="YES"/>
 										<integer value="1040"/>
@@ -322,6 +327,7 @@
 								<reference key="NSColor" ref="13767475"/>
 							</object>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSButton" id="17421192">
 						<reference key="NSNextResponder" ref="185234335"/>
@@ -332,12 +338,12 @@
 						<reference key="NSNextKeyView" ref="328560324"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="96932987">
-							<int key="NSCellFlags">-2080244224</int>
+							<int key="NSCellFlags">-2080374784</int>
 							<int key="NSCellFlags2">0</int>
 							<string key="NSContents">Don't show more than</string>
 							<reference key="NSSupport" ref="1057182896"/>
 							<reference key="NSControlView" ref="17421192"/>
-							<int key="NSButtonFlags">1211912703</int>
+							<int key="NSButtonFlags">1211912448</int>
 							<int key="NSButtonFlags2">2</int>
 							<object class="NSCustomResource" key="NSNormalImage" id="538943662">
 								<string key="NSClassName">NSImage</string>
@@ -351,6 +357,7 @@
 							<int key="NSPeriodicDelay">200</int>
 							<int key="NSPeriodicInterval">25</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSButton" id="497135971">
 						<reference key="NSNextResponder" ref="185234335"/>
@@ -358,14 +365,15 @@
 						<string key="NSFrame">{{163, 18}, {196, 18}}</string>
 						<reference key="NSSuperview" ref="185234335"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="492552876">
-							<int key="NSCellFlags">-2080244224</int>
+							<int key="NSCellFlags">-2080374784</int>
 							<int key="NSCellFlags2">0</int>
 							<string key="NSContents">Open in browser if possible</string>
 							<reference key="NSSupport" ref="1057182896"/>
 							<reference key="NSControlView" ref="497135971"/>
-							<int key="NSButtonFlags">1211912703</int>
+							<int key="NSButtonFlags">1211912448</int>
 							<int key="NSButtonFlags2">2</int>
 							<reference key="NSNormalImage" ref="538943662"/>
 							<reference key="NSAlternateImage" ref="931361930"/>
@@ -374,6 +382,7 @@
 							<int key="NSPeriodicDelay">200</int>
 							<int key="NSPeriodicInterval">25</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSButton" id="777792219">
 						<reference key="NSNextResponder" ref="185234335"/>
@@ -384,12 +393,12 @@
 						<reference key="NSNextKeyView" ref="497135971"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="300830423">
-							<int key="NSCellFlags">-2080244224</int>
+							<int key="NSCellFlags">-2080374784</int>
 							<int key="NSCellFlags2">0</int>
 							<string key="NSContents">Show diff when clicked</string>
 							<reference key="NSSupport" ref="1057182896"/>
 							<reference key="NSControlView" ref="777792219"/>
-							<int key="NSButtonFlags">1211912703</int>
+							<int key="NSButtonFlags">1211912448</int>
 							<int key="NSButtonFlags2">2</int>
 							<reference key="NSNormalImage" ref="538943662"/>
 							<reference key="NSAlternateImage" ref="931361930"/>
@@ -398,6 +407,7 @@
 							<int key="NSPeriodicDelay">200</int>
 							<int key="NSPeriodicInterval">25</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSTextField" id="996414272">
 						<reference key="NSNextResponder" ref="185234335"/>
@@ -408,7 +418,7 @@
 						<reference key="NSNextKeyView" ref="467224366"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSTextFieldCell" key="NSCell" id="574820938">
-							<int key="NSCellFlags">68288064</int>
+							<int key="NSCellFlags">68157504</int>
 							<int key="NSCellFlags2">272630784</int>
 							<string key="NSContents">New commits:</string>
 							<reference key="NSSupport" ref="1057182896"/>
@@ -416,6 +426,7 @@
 							<reference key="NSBackgroundColor" ref="199757900"/>
 							<reference key="NSTextColor" ref="122213290"/>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSButton" id="467224366">
 						<reference key="NSNextResponder" ref="185234335"/>
@@ -426,12 +437,12 @@
 						<reference key="NSNextKeyView" ref="17421192"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="684923184">
-							<int key="NSCellFlags">-2080244224</int>
+							<int key="NSCellFlags">-2080374784</int>
 							<int key="NSCellFlags2">0</int>
 							<string key="NSContents">Keep notifications on screen</string>
 							<reference key="NSSupport" ref="1057182896"/>
 							<reference key="NSControlView" ref="467224366"/>
-							<int key="NSButtonFlags">1211912703</int>
+							<int key="NSButtonFlags">1211912448</int>
 							<int key="NSButtonFlags2">2</int>
 							<reference key="NSNormalImage" ref="538943662"/>
 							<reference key="NSAlternateImage" ref="931361930"/>
@@ -440,6 +451,7 @@
 							<int key="NSPeriodicDelay">200</int>
 							<int key="NSPeriodicInterval">25</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSButton" id="69059234">
 						<reference key="NSNextResponder" ref="185234335"/>
@@ -450,12 +462,12 @@
 						<reference key="NSNextKeyView" ref="601672583"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="545050183">
-							<int key="NSCellFlags">-2080244224</int>
+							<int key="NSCellFlags">-2080374784</int>
 							<int key="NSCellFlags2">0</int>
 							<string key="NSContents">Ignore my own commits</string>
 							<reference key="NSSupport" ref="1057182896"/>
 							<reference key="NSControlView" ref="69059234"/>
-							<int key="NSButtonFlags">1211912703</int>
+							<int key="NSButtonFlags">1211912448</int>
 							<int key="NSButtonFlags2">2</int>
 							<reference key="NSNormalImage" ref="538943662"/>
 							<reference key="NSAlternateImage" ref="931361930"/>
@@ -464,6 +476,7 @@
 							<int key="NSPeriodicDelay">200</int>
 							<int key="NSPeriodicInterval">25</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 					<object class="NSButton" id="601672583">
 						<reference key="NSNextResponder" ref="185234335"/>
@@ -474,12 +487,12 @@
 						<reference key="NSNextKeyView" ref="777792219"/>
 						<bool key="NSEnabled">YES</bool>
 						<object class="NSButtonCell" key="NSCell" id="697033229">
-							<int key="NSCellFlags">-2080244224</int>
+							<int key="NSCellFlags">-2080374784</int>
 							<int key="NSCellFlags2">0</int>
 							<string key="NSContents">Ignore merge commits</string>
 							<reference key="NSSupport" ref="1057182896"/>
 							<reference key="NSControlView" ref="601672583"/>
-							<int key="NSButtonFlags">1211912703</int>
+							<int key="NSButtonFlags">1211912448</int>
 							<int key="NSButtonFlags2">2</int>
 							<reference key="NSNormalImage" ref="538943662"/>
 							<reference key="NSAlternateImage" ref="931361930"/>
@@ -488,12 +501,13 @@
 							<int key="NSPeriodicDelay">200</int>
 							<int key="NSPeriodicInterval">25</int>
 						</object>
+						<bool key="NSAllowsLogicalLayoutDirection">NO</bool>
 					</object>
 				</object>
 				<string key="NSFrameSize">{525, 327}</string>
 				<reference key="NSSuperview"/>
 				<reference key="NSWindow"/>
-				<reference key="NSNextKeyView" ref="996414272"/>
+				<reference key="NSNextKeyView" ref="99672514"/>
 				<string key="NSClassName">NSView</string>
 			</object>
 			<object class="NSUserDefaultsController" id="983611490">
@@ -983,7 +997,7 @@
 					<string>65.IBPluginDependency</string>
 					<string>85.IBPluginDependency</string>
 				</object>
-				<object class="NSMutableArray" key="dict.values">
+				<object class="NSArray" key="dict.values">
 					<bool key="EncodedWithXMLCoder">YES</bool>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
 					<string>com.apple.InterfaceBuilder.CocoaPlugin</string>
@@ -1061,7 +1075,7 @@
 							<string>growlInfoPanel</string>
 							<string>ignoreOwnEmailsField</string>
 						</object>
-						<object class="NSMutableArray" key="dict.values">
+						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<string>NSView</string>
 							<string>NSButton</string>
@@ -1074,7 +1088,7 @@
 							<string>growlInfoPanel</string>
 							<string>ignoreOwnEmailsField</string>
 						</object>
-						<object class="NSMutableArray" key="dict.values">
+						<object class="NSArray" key="dict.values">
 							<bool key="EncodedWithXMLCoder">YES</bool>
 							<object class="IBToOneOutletInfo">
 								<string key="name">growlInfoPanel</string>
@@ -1108,7 +1122,7 @@
 				<string>NSSwitch</string>
 				<string>growl_icon</string>
 			</object>
-			<object class="NSMutableArray" key="dict.values">
+			<object class="NSArray" key="dict.values">
 				<bool key="EncodedWithXMLCoder">YES</bool>
 				<string>{15, 15}</string>
 				<string>{64, 64}</string>


### PR DESCRIPTION
These commits add Notification Center support on Mountain Lion. (#47)
Growl is preferred, if it is installed. On Lion and older, everything stays the same, too.
