### PR TITLE
Only do a shallow clone to save disk space.

### DIFF
--- a/Classes/Repository.m
+++ b/Classes/Repository.m
@@ -112,7 +112,7 @@ static NSString *commitRangeRegexp = @"[0-9a-f]+\\.\\.[0-9a-f]+";
 
   if (cachesDirectoryExists && workingCopyDoesntExist) {
     isBeingUpdated = YES;
-    [git runCommand: @"clone" withArguments: @[self.url, workingCopy, @"-n"] inPath: cachesDirectory];
+    [git runCommand: @"clone" withArguments: @[self.url, workingCopy, @"-n", @"--depth", @"1"] inPath: cachesDirectory];
   } else {
     [self notifyDelegateWithSelector: @selector(repositoryCouldNotBeCloned:)];
   }


### PR DESCRIPTION
A clone with --depth 1 saves a ton of disk space and should cover everything Gitifier needs.
